### PR TITLE
Add contract & test for user registration with email and password

### DIFF
--- a/contracts/Users.sol
+++ b/contracts/Users.sol
@@ -1,0 +1,35 @@
+pragma solidity >=0.4.21 <0.7.0;
+
+contract Users
+{
+    struct User {
+        string email;
+        bytes32 password;
+        bool registered;
+        // Add any data here about the voter that we also need
+    }
+
+    mapping(string => User) private users;
+
+    function register(string memory email, string memory password) public returns (bool) {
+        // Check if user is already registered
+        if (users[email].registered == true) {
+            return false;
+        }
+
+        // Register user data
+        users[email].email = email;
+        users[email].password = keccak256(abi.encodePacked(password)); // Store hashed for security and later comparisons.
+        users[email].registered = true;
+
+        return true; // Registration success
+    }
+
+    function login(string memory email, string memory password) public view returns (bool) {
+        if (users[email].password == keccak256(abi.encodePacked(password))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/contracts/tests/UsersTest.sol
+++ b/contracts/tests/UsersTest.sol
@@ -1,0 +1,25 @@
+pragma solidity >=0.4.21 <0.7.0;
+
+import "remix_tests.sol"; // this import is automatically injected by Remix.
+import "../contracts/Users.sol";
+
+contract UsersTest {
+    Users users;
+
+    function beforeAll () public {
+        users = new Users();
+    }
+
+    function registerUsers() public {
+        Assert.equal(users.register("test1@site.com", "password123"), true, "test1@site.com should be able to register.");
+        Assert.equal(users.register("test1@site.com", "password123"), false, "test1@site.com should not be able to register twice.");
+        Assert.equal(users.register("test2@site.com", "456Password"), true, "test2@site.com should be able to register.");
+    }
+
+    function loginUsers() public {
+        Assert.equal(users.login("test1@site.com", "wrongPassword"), false, "test1@site.com should not be able to login with a wrong password.");
+        Assert.equal(users.login("test1@site.com", "password123"), true, "test1@site.com should be able to login with the correct password.");
+        Assert.equal(users.login("test2@site.com", "456password"), false, "test2@site.com should not be able to login with a wrong password due to case sensitivity.");
+        Assert.equal(users.login("test2@site.com", "456Password"), true, "test2@site.com should be able to login with the correct password.");
+    }
+}


### PR DESCRIPTION
Removed in favor of forked repo.

Use this if you're interested in having email, password combinations instead of facial recognition. Still needs to be hooked up to the existing system.